### PR TITLE
Add version control dropdown to layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ htmlcov
 .vscode
 .idea
 .pytest_cache/
+.doctrees/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,6 +44,10 @@ html_theme = "nengo_sphinx_theme"
 html_logo = os.path.join("_static", "logo.svg")
 html_sidebars = {"**": ["sidebar.html"]}
 html_last_updated_fmt = ""  # Suppress "Last updated on:" timestamp
+html_context = {
+    "building_version": "latest",
+    "releases": "404",
+}
 html_theme_options = {
     "hidesidebar": "true",
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,7 @@ extensions = [
     "sphinx.ext.todo",
     "nengo_sphinx_theme",
     "nengo_sphinx_theme.ext.canonical_url",
+    "nengo_sphinx_theme.ext.versions",
 ]
 
 

--- a/docs/deeply/nested/testing/page.rst
+++ b/docs/deeply/nested/testing/page.rst
@@ -1,0 +1,9 @@
+:orphan:
+
+***********************
+Deeply nested test page
+***********************
+
+This page is deeply nested to ensure that
+various links to pages
+handle deeply nested pages correctly.

--- a/docs/test.rst
+++ b/docs/test.rst
@@ -8,8 +8,11 @@ to make sure everything is displaying correctly.
 This page is based on the `Cloud Sphinx theme's feature test
 <https://cloud-sptheme.readthedocs.io/en/latest/cloud_theme_test.html>`_.
 
+Styling
+=======
+
 Text
-====
+----
 
 Inline literal: ``literal text``
 
@@ -22,7 +25,7 @@ Email link: bob@example.com
 *Italic text*
 
 Math
-====
+----
 
 Inline math: :math:`a^2 + b^2 = c^2`
 
@@ -34,7 +37,7 @@ Displayed math, with a label:
 Equation reference: :eq:`euler`
 
 Admonitions
-===========
+-----------
 
 .. note:: This is a note.
 
@@ -63,34 +66,36 @@ Admonitions
    This was changed.
 
 Code
-====
+----
 
-Python code block:
+Python code block with line numbers:
 
 .. code-block:: python
-    :linenos:
+   :linenos:
 
-    >>> import os
+   >>> import os
 
-    >>> os.listdir("/home")
-    ['bread', 'pudding']
+   >>> os.listdir("/home")
+   ['bread', 'pudding']
 
-    >>> os.listdir("/root")
-    Traceback (most recent call last):
-      File "<stdin>", line 1, in <module>
-    OSError: [Errno 13] Permission denied: '/root'
+   >>> os.listdir("/root")
+   Traceback (most recent call last):
+     File "<stdin>", line 1, in <module>
+   OSError: [Errno 13] Permission denied: '/root'
 
 INI code block:
 
 .. code-block:: ini
-    :linenos:
 
-    [rueben]
-    bread = rye
-    meat = corned beef
-    veg = sauerkraut
+   [rueben]
+   bread = rye
+   meat = corned beef
+   veg = sauerkraut
 
-Function styling:
+Documentation
+-------------
+
+Function:
 
 .. function:: frobfunc(foo=1, *, bar=False)
 
@@ -105,7 +110,7 @@ Function styling:
 
     :raises TypeError: if *foo* is out of range
 
-Class styling:
+Class:
 
 .. class:: FrobClass(foo=1, *, bar=False)
 
@@ -124,7 +129,7 @@ Class styling:
         execute action, return result.
 
 Tables
-======
+------
 
 .. table:: Normal Table
 
@@ -148,8 +153,11 @@ Tables
     Row 3       Row 3       Row 3
     =========== =========== ===========
 
-Normal section
-==============
+Extensions
+==========
 
-Child section
--------------
+Versioning
+----------
+
+:doc:`deeply/nested/testing/page`
+versioned links work properly.

--- a/nengo_sphinx_theme/ext/versions.py
+++ b/nengo_sphinx_theme/ext/versions.py
@@ -1,0 +1,23 @@
+import warnings
+
+from sphinx.errors import ConfigError
+
+
+def validate_config(app, config):
+    html_context = getattr(config, "html_context", {})
+    releases = html_context.get("releases", "").split(",")
+    building = html_context.get("building_version", "")
+
+    if "latest" in releases:
+        raise ConfigError(
+            "nengo_sphinx_theme.ext.versions: 'latest' cannot be a release "
+            "name (link to the most up-to-date version of the docs will be "
+            "added automatically)")
+
+    if building == "":
+        warnings.warn(
+            "'building_version' not set, versions will not be rendered")
+
+
+def setup(app):
+    app.connect("config-inited", validate_config)

--- a/nengo_sphinx_theme/theme/layout.html
+++ b/nengo_sphinx_theme/theme/layout.html
@@ -52,6 +52,7 @@
       {%- endif %}
       <div class="col-md-8 col-lg-9">
         <div class="wrapper-content-right">
+          {% include "versions.html" %}
           {% block body %}{% endblock %}
         </div>
       </div>

--- a/nengo_sphinx_theme/theme/navbar.html
+++ b/nengo_sphinx_theme/theme/navbar.html
@@ -1,7 +1,7 @@
 <header class="header-nav">
   <div class="container">
     <div class="navbar w-nav" data-animation="default" data-collapse="small" data-contain="1" data-duration="400">
-      <a class="brand w-nav-brand" href="index.html">
+      <a class="brand w-nav-brand" href="https://www.nengo.ai/">
         <img src="https://www.nengo.ai/design/_images/full-light.svg" width="120">
       </a>
       <nav class="w-nav-menu main-nav" role="navigation">

--- a/nengo_sphinx_theme/theme/static/css/nengo.css
+++ b/nengo_sphinx_theme/theme/static/css/nengo.css
@@ -366,11 +366,6 @@ table.sub-menu td:last-child {
         padding-right: 0;
     }
 
-    body .wrapper-navleft,
-    body #nav-affix {
-        max-width: 240px;
-    }
-
     .brand.w-nav-brand {
         padding-left: 0;
     }
@@ -412,11 +407,6 @@ table.sub-menu td:last-child {
 #nav-affix {
     width: 100%;
     margin: 0;
-}
-
-.wrapper-navleft,
-#nav-affix {
-    max-width: 260px;
 }
 
 .wrapper-navleft,
@@ -1037,11 +1027,6 @@ p {
     line-height: 1.5em;
 }
 
-a {
-    color: #6ea6d6;
-    text-decoration: none;
-}
-
 a:hover {
     opacity: 0.7;
     color: #6ea6d6;
@@ -1435,7 +1420,7 @@ header .brand {
 }
 
 .wrapper-navleft {
-    width: 240px;
+    width: 100%;
     margin-right: 32px;
     margin-bottom: 32px;
     padding: 8px 16px;
@@ -1998,8 +1983,19 @@ a.learn-more-link, .wrapper-teaser-img p {
 }
 
 .version-select-container {
-    float: right;
-    text-align: right;
+    display: inline-block;
+    position: absolute;
+    margin-right: 31px;
+    margin-top: 8px;
+    right: 0;
+}
+
+#sourcelink {
+    margin-top: 8px;
+}
+
+.version-select-container .toggle-text {
+    color: #6ea6d6;
 }
 
 .toggle {
@@ -2504,7 +2500,6 @@ html.w-mod-js *[data-ix="hide-color-logo"] {
     }
     .wrapper-navleft {
         display: none;
-        width: 100%;
         float: none;
     }
     .wrapper-content-right {
@@ -2737,52 +2732,52 @@ html.w-mod-js *[data-ix="hide-color-logo"] {
         max-width: 100%;
         margin-left: 0px;
         float: none;
-  }
-  .home-values-text-wrapper {
-    font-size: 16px;
-    line-height: 22px;
-  }
-  .home-values-headline {
-    font-size: 16px;
-    line-height: 22px;
-  }
-  .home-usecases-text-wrapper {
-    margin-bottom: 32px;
-    padding-left: 16px;
-  }
-  .margin-0 {
-    margin-right: 0px;
-    margin-bottom: 0px;
-    margin-left: 0px;
-  }
-  .option {
-    display: block;
-  }
-  .option:active {
-    background-color: #e9f9fd;
-  }
-  .wrapper-option {
-    padding: 16px;
-  }
-  .option-icon {
-    margin-right: 16px;
-  }
-  .wrapper-option-text {
-    padding-left: 64px;
-  }
+    }
+    .home-values-text-wrapper {
+        font-size: 16px;
+        line-height: 22px;
+    }
+    .home-values-headline {
+        font-size: 16px;
+        line-height: 22px;
+    }
+    .home-usecases-text-wrapper {
+        margin-bottom: 32px;
+        padding-left: 16px;
+    }
+    .margin-0 {
+        margin-right: 0px;
+        margin-bottom: 0px;
+        margin-left: 0px;
+    }
+    .option {
+        display: block;
+    }
+    .option:active {
+        background-color: #e9f9fd;
+    }
+    .wrapper-option {
+        padding: 16px;
+    }
+    .option-icon {
+        margin-right: 16px;
+    }
+    .wrapper-option-text {
+        padding-left: 64px;
+    }
 }
 @media screen and (max-width: 991px) {
 
-  #notification {
-    display: none !important;
-  }
+    #notification {
+        display: none !important;
+    }
 }
 
 @font-face {
-  font-family: 'Blender Pro';
-  src: url('../fonts/BlenderPro-Bold.ttf') format('truetype'), url('../fonts/BlenderPro-Thin.ttf') format('truetype');
-  font-weight: 400;
-  font-style: normal;
+    font-family: 'Blender Pro';
+    src: url('../fonts/BlenderPro-Bold.ttf') format('truetype'), url('../fonts/BlenderPro-Thin.ttf') format('truetype');
+    font-weight: 400;
+    font-style: normal;
 }
 
 .wrapper-navleft .bs-sidenav img.logo {

--- a/nengo_sphinx_theme/theme/versions.html
+++ b/nengo_sphinx_theme/theme/versions.html
@@ -1,0 +1,28 @@
+{% if building_version %}
+<div class="version-select-container">
+    <div data-delay="0" class="w-dropdown">
+        <div class="w-dropdown-toggle toggle">
+            <div class="toggle-text">{{ building_version }}</div>
+            <div class="w-icon-dropdown-toggle toggle-icon"></div>
+        </div>
+        <nav class="w-dropdown-list dropdown-list">
+            {% set prefix = pagename | list | select("equalto", "/") | map("replace", "/", "../") | join("") %}
+            {% if building_version == "latest" %}
+                <div class="w-dropdown-link">latest</div>
+            {% else %}
+                <a href="{{ prefix }}../{{ pagename }}.html" class="w-dropdown-link">latest</a>
+            {% endif %}
+
+            {% for release in releases.split(",") | sort(True) %}
+                {% if building_version == release %}
+                <div class="w-dropdown-link">{{ release }}</div>
+                {% elif building_version == "latest" %}
+                    <a href="{{ prefix }}{{ release }}/{{ pagename }}.html" class="w-dropdown-link">{{ release }}</a>
+                {% else %}
+                    <a href="{{ prefix }}../{{ release }}/{{ pagename }}.html" class="w-dropdown-link">{{ release }}</a>
+                {% endif %}
+            {% endfor %}
+        </nav>
+    </div>
+</div>
+{% endif %}

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ root = os.path.dirname(os.path.realpath(__file__))
 version_module = imp.load_source(
     "version", os.path.join(root, "nengo_sphinx_theme", "version.py"))
 
-install_requires = ["sphinx"]
+install_requires = ["sphinx>=1.8"]
 
 setup(
     name="nengo-sphinx-theme",


### PR DESCRIPTION
This is based on a template I made for NengoDL.  I made it a separate file so that it is easy for backends to change the template if they want (as it seems likely that different backends might want to tweak the display according to their own versioning system).

It is controlled by passing two flags to the sphinx build process, `building_version` and `releases`.  `building_version` specifies which version of the documentation is currently being built (with special name "latest" signifying the most up-to-date version).  `releases` is a semi-colon-separated list of past versions of the documentation we want to include (named "releases" because this probably corresponds to one documentation version for each public release).  It is assumed that these previous versions of the documentation have been built into subfolders of the root doc build, with the name of each subfolder corresponding to the name of the release.

For example
```
sphinx-build -b html docs docs/_build -A building_version=latest -A releases=v1.0.0;v1.1.0;v1.2.0
```

will give you a versioning dropdown that looks like

<img width="83" alt="capture" src="https://user-images.githubusercontent.com/1952220/45638359-5be4bf00-ba83-11e8-90b6-1cac9b6ef4ab.PNG">

You would build the other versions with, e.g.,
```
sphinx-build -b html docs docs/_build/v1.0.0 -A building_version=v1.0.0 -A releases=v1.0.0;v1.1.0;v1.2.0
```
(although I'd recommend setting up the doc build CI in such a way that those are saved automatically, rather than rebuilding them each time).

Note that if the `building_version` tag is omitted then there is no version dropdown displayed, so projects don't need to care about this unless they want to.