### PR TITLE
Reorganize documentation submenu

### DIFF
--- a/nengo_sphinx_theme/theme/navbar.html
+++ b/nengo_sphinx_theme/theme/navbar.html
@@ -9,30 +9,44 @@
           <span class="arrow"></span>
         </div>
         <ul id="menu-top-navigation" class="menu">
-          <li class="navlink w-nav-link menu-item"><a href="https://www.nengo.ai/overview.html">Overview</a></li>
+          <li class="navlink w-nav-link menu-item menu-item-has-children">
+            <a href="https://www.nengo.ai/overview.html">Overview</a>
+            <ul class="sub-menu">
+                <li class="menu-item"><a href="https://www.nengo.ai/quickstart.html">Quick Start</a></li>
+            </ul>
+          </li>
           <li class="navlink w-nav-link menu-item menu-item-has-children">
             <a href="https://www.nengo.ai/documentation.html">Documentation</a>
             <table class="sub-menu">
               <tr>
-                <td class="menu-item" colspan="2"><a href="https://www.nengo.ai/quickstart.html">Quick Start</a></td>
-                <td class="menu-item" colspan="2"><a href="https://www.nengo.ai/publications.html">Publications</a></td>
-                <td class="menu-item" colspan="2"><a href="https://www.nengo.ai/videos.html">Videos</a></td>
+                <td class="menu-heading">Core</td>
+                <td class="menu-heading">Backends</td>
+                <td class="menu-heading">Add-ons</td>
               </tr>
               <tr>
-                <td class="menu-item"><a href="https://www.nengo.ai/nengo">Nengo Core</a></td>
-                <td class="menu-item"><a href="https://github.com/nengo/nengo-gui">Nengo GUI</a></td>
-                <td class="menu-item"><a href="https://www.nengo.ai/nengo-extras/">Nengo Extras</a></td>
-                <td class="menu-item"><a href="https://www.nengo.ai/nengo-spa/">Nengo SPA</a></td>
-                <td class="menu-item"><a href="https://arvoelke.github.io/nengolib-docs/">NengoLib</a></td>
+                <td class="menu-item"><a href="https://www.nengo.ai/nengo">Nengo</a></td>
+                <td class="menu-item"><a href="https://www.nengo.ai/nengo-fpga">Nengo FPGA</a></td>
                 <td class="menu-item"><a href="https://github.com/nengo/nengo-examples">Nengo Examples</a></td>
               </tr>
               <tr>
-                <td class="menu-item"><a href="https://www.nengo.ai/nengo-dl/">NengoDL</a></td>
-                <td class="menu-item"><a href="https://www.nengo.ai/nengo-fpga">Nengo FPGA</a></td>
+                <td class="menu-item"><a href="https://www.nengo.ai/nengo-dl/">Nengo DL</a></td>
                 <td class="menu-item"><a href="https://www.nengo.ai/nengo-loihi">Nengo Loihi</a></td>
-                <td class="menu-item"><a href="https://github.com/project-rig/nengo_spinnaker">Nengo SpiNNaker</a></td>
-                <td class="menu-item"><a href="https://github.com/nengo/nengo-ocl">Nengo OpenCL</a></td>
+                <td class="menu-item"><a href="https://www.nengo.ai/nengo-extras/">Nengo Extras</a></td>
+              </tr>
+              <tr>
+                <td class="menu-item"><a href="https://github.com/nengo/nengo-gui">Nengo GUI</a></td>
                 <td class="menu-item"><a href="https://github.com/nengo/nengo-mpi">Nengo MPI</a></td>
+                <td class="menu-item"><a href="https://arvoelke.github.io/nengolib-docs/">Nengo Lib</a></td>
+              </tr>
+              <tr>
+                <td class="menu-item"><a href="https://www.nengo.ai/nengo-spa/">Nengo SPA</a></td>
+                <td class="menu-item"><a href="https://github.com/nengo/nengo-ocl">Nengo OpenCL</a></td>
+                <td class="menu-item"></td>
+              </tr>
+              <tr>
+                <td class="menu-item"></td>
+                <td class="menu-item"><a href="https://github.com/project-rig/nengo_spinnaker">Nengo SpiNNaker</a></td>
+                <td class="menu-item"></td>
               </tr>
             </table>
           </li>
@@ -40,7 +54,9 @@
             <a href="https://www.nengo.ai/community.html">Community</a>
             <ul class="sub-menu">
               <li class="menu-item"><a href="https://forum.nengo.ai/">Forum</a></li>
+              <li class="menu-item"><a href="https://www.nengo.ai/publications.html">Publications</a></li>
               <li class="menu-item"><a href="https://www.nengo.ai/summerschool.html">Summer School</a></li>
+              <li class="menu-item"><a href="https://www.nengo.ai/videos.html">Videos</a></li>
               <li class="menu-item"><a href="https://www.nengo.ai/people.html">People</a></li>
             </ul>
           </li>

--- a/nengo_sphinx_theme/theme/static/css/nengo.css
+++ b/nengo_sphinx_theme/theme/static/css/nengo.css
@@ -282,7 +282,7 @@ body .mm-menu .navbar-nav {
 td.menu-item a {
     display: block;
     padding: 8px;
-    text-align: center;
+    text-align: left;
     white-space: nowrap;
 }
 
@@ -290,10 +290,41 @@ td.menu-item a:hover {
     background-color: #f1f1f1;
 }
 
+td.menu-heading {
+    text-align: center;
+    font-weight: bold;
+    padding: 8px;
+    font-size: 14px;
+}
+
+.main-nav .menu-item-has-children table.sub-menu {
+    border: none;
+    border-collapse: collapse;
+    padding-left: 0;
+    padding-right: 0;
+}
+
+table.sub-menu td {
+    border-left: 2px solid #f1f1f1;
+    border-right: 2px solid #f1f1f1;
+}
+
+table.sub-menu td a {
+    width: 150px;
+}
+
+table.sub-menu td:first-child {
+    border-left: none;
+}
+
+table.sub-menu td:last-child {
+    border-right: none;
+}
 
 @media screen and (max-width: 991px) {
     .main-nav ul.menu > li.menu-item > a {
-        padding: 5px;
+        padding-left: 5px;
+        padding-right: 5px;
         font-size: 14px;
     }
 }


### PR DESCRIPTION
This is an idea for reworking the documentation menu.  The main goal is to add a bit more structure to the list of Nengo projects, as well as more clearly direct users to the "core" projects.  The categorization of "core projects" is pretty subjective, but I think of it roughly as "these are the things we want _every_ Nengo user to know about".  "Backends" are things that users interested in a specific platform would want to know about, and "Libraries" is kind of a catch-all for everything else (things that users can discover as they seek out more information).

I also wanted the "Documentation" tab to only have links to projects' documentation, to give it a clear semantic category.  So I moved "Publications" and "Videos" to the "Resources" tab (formerly "Community"), and "Quick Start" to "Overview".

Here's what it looks like:
<img width="755" alt="capture2" src="https://user-images.githubusercontent.com/1952220/45644251-aff79f80-ba93-11e8-85ae-53348fa34c09.PNG">

(the text doesn't actually look grey like that, that's just something weird with my screen capture.  It's black/white like all the other menus)