### PR TITLE
Fix footer links

### DIFF
--- a/nengo_sphinx_theme/theme/footer.html
+++ b/nengo_sphinx_theme/theme/footer.html
@@ -5,17 +5,17 @@
         <div class="w-col w-col-2 footer-menu">
           <p class="menu-Label">ABR, Inc.</p>
           <ul class="vertical-menu">
-            <li class="footer-listitem-new"><a href="https://appliedbrainresearch.com">Products</a></li>
-            <li class="footer-listitem-new "><a href="https://appliedbrainresearch.com">Services</a></li>
-            <li class="footer-listitem-new"><a href="https://appliedbrainresearch.com/projects">Research</a></li>
+            <li class="footer-listitem-new"><a href="https://appliedbrainresearch.com/products/">Products</a></li>
+            <li class="footer-listitem-new "><a href="https://appliedbrainresearch.com/services/">Services</a></li>
+            <li class="footer-listitem-new"><a href="https://appliedbrainresearch.com/research/">Research</a></li>
           </ul>
         </div>
         <div class="w-col w-col-2 footer-menu">
           <p class="menu-Label">About Us</p>
           <ul class="vertical-menu">
-            <li class="footer-listitem-new"><a href="https://appliedbrainresearch.com/contact">Contact</a></li>
-            <li class="footer-listitem-new"><a href="https://appliedbrainresearch.com/team">Team</a></li>
-            <li class="footer-listitem-new"><a href="https://appliedbrainresearch.com/culture">Culture</a></li>
+            <li class="footer-listitem-new"><a href="https://appliedbrainresearch.com/about-us/">Contact</a></li>
+            <li class="footer-listitem-new"><a href="https://appliedbrainresearch.com/about-us/#team">Team</a></li>
+            <li class="footer-listitem-new"><a href="https://appliedbrainresearch.com/about-us/#culture">Culture</a></li>
           </ul>
         </div>
         <a class="brand footer-brand" href="https://appliedbrainresearch.com">


### PR DESCRIPTION
These were essentially placeholders for when we finished the first round of the ABR website redesign. Now that that's up we can fill them in with real links.