### PR TITLE
Ensure top navbar stays on top

### DIFF
--- a/nengo_sphinx_theme/theme/static/js/custom.js
+++ b/nengo_sphinx_theme/theme/static/js/custom.js
@@ -95,4 +95,8 @@ $(document).ready(function() {
       $('.wrapper-navleft').toggle();
     });
   }
+
+  // Sometimes the top navbar gets reordered. Put it back up top, just in case
+  var header = document.querySelector('header.header-nav');
+  document.body.insertBefore(header, document.body.firstChild);
 });


### PR DESCRIPTION
Sometimes during a page load, an element will get placed above the top navbar. This occurs in unknown circumstances, but those circumstances seem to come up often enough that we need to fix this in all cases. It's a bit of a hack.