### PR TITLE
Set body class for sphinx 2.0 compatibility

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,12 +22,15 @@ Release History
 0.10.0 (unreleased)
 ===================
 
+**Fixed**
 
+- Added ``body`` class to main div for compatibility with sphinx 2.0.
+  (`#26 <https://github.com/nengo/nengo-sphinx-theme/pull/26>`__)
 
 0.9.0 (March 25, 2019)
 ======================
 
 **Added**
 
-- Added search box to sidebar
-  (`#25 <https://github.com/nengo/nengo-sphinx-theme/pull/25>`_)
+- Added search box to sidebar.
+  (`#25 <https://github.com/nengo/nengo-sphinx-theme/pull/25>`__)

--- a/nengo_sphinx_theme/theme/layout.html
+++ b/nengo_sphinx_theme/theme/layout.html
@@ -29,7 +29,7 @@
         </aside>
       </div>
       <div class="col-md-8 col-lg-9">
-        <div class="wrapper-content-right">
+        <div class="body wrapper-content-right">
           {% include "versions.html" %}
           {% block body %}{% endblock %}
         </div>


### PR DESCRIPTION
Apparently sphinx expects the main body to be given the ``body`` class (see https://github.com/sphinx-doc/sphinx/issues/6170#issuecomment-473622567).  Previously the fact that we weren't doing this doesn't seem to have made a difference, but as of the sphinx 2.0 release it causes all of the text in tables to be centre-aligned if you don't have this.

Confirmed that this fixes the issue for sphinx 2.0, and doesn't cause a difference in sphinx 1.8.