### PR TITLE
Fix for menu dropdown covering content on website

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,11 @@ Release History
 0.11.0 (unreleased)
 ===================
 
+**Fixed**
 
+- Fixed an issue in which the dropdown overlay prevented clicks
+  after it had been hidden from mousing outside of it.
+  (`#29 <https://github.com/nengo/nengo-sphinx-theme/pull/29>`__)
 
 0.10.0 (March 30, 2019)
 =======================

--- a/nengo_sphinx_theme/theme/static/css/nengo.css
+++ b/nengo_sphinx_theme/theme/static/css/nengo.css
@@ -179,9 +179,6 @@ body .main-nav .sub-menu li a {
     transition: all 0.25s;
     -webkit-transform-origin: 50% 0%;
     transform-origin: 50% 0%;
-    display: -webkit-box;
-    display: -ms-flexbox;
-    display: flex;
     -webkit-box-pack: center;
     -ms-flex-pack: center;
     justify-content: center;
@@ -191,12 +188,16 @@ body .main-nav .sub-menu li a {
     border-top: 2px solid #6ea6d6;
     -webkit-box-shadow: 1px 1px 5px rgba(0,0,0,0.2);
     box-shadow: 1px 1px 5px rgba(0,0,0,0.2);
+    display: none;
 }
 
 .dropdownBackground.open {
     opacity: 1;
     -webkit-transform: translateY(65px);
     transform: translateY(65px);
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
 }
 
 .arrow {


### PR DESCRIPTION
The overlay wasn't being hidden properly, so when you hovered over the menu and then moved outside of it it would cover the content and prevent users from being able to click on any links under it. 