### PR TITLE
Add extension for expanding Default parameters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,12 @@ Release History
 0.12.0 (unreleased)
 ===================
 
+**Added**
 
+- Added ``nengo_sphinx_theme.ext.resolvedefaults`` extension that will
+  automatically fill in the value of ``nengo.Default`` values in
+  ``__init__`` signatures.
+  (`#33 <https://github.com/nengo/nengo-sphinx-theme/pull/33>`_)
 
 0.11.0 (May 20, 2019)
 =====================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,8 +11,8 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.todo",
     "nengo_sphinx_theme",
+    "nengo_sphinx_theme.ext.resolvedefaults",
 ]
-
 
 # -- sphinx
 nitpicky = True

--- a/docs/test.rst
+++ b/docs/test.rst
@@ -170,3 +170,10 @@ Versioning
 
 :doc:`deeply/nested/testing/page`
 versioned links work properly.
+
+Default resolution
+------------------
+
+Autodoc with default resolution:
+
+.. autoclass:: nengo_sphinx_theme.ext.resolvedefaults.TestClass

--- a/nengo_sphinx_theme/ext/resolvedefaults.py
+++ b/nengo_sphinx_theme/ext/resolvedefaults.py
@@ -1,0 +1,68 @@
+import inspect
+import warnings
+
+from nengo.params import Default, IntParam, iter_params, StringParam
+
+
+class TestClass:
+    """For testing that defaults are properly rendered in docs."""
+
+    int_param = IntParam("int_param", default=1)
+    str_param = StringParam("str_param", default="hello")
+
+    def __init__(self, int_param=Default, str_param=Default):
+        pass
+
+
+class DisplayDefault:
+    def __init__(self, value):
+        self.value = value
+
+    def __repr__(self):
+        return "Default<{!r}>".format(self.value)
+
+
+def resolve_default(cls, arg, value):
+    if value is not Default:
+        return value
+    else:
+        for param in (getattr(cls, name) for name in iter_params(cls)):
+            if param.name == arg:
+                return DisplayDefault(param.default)
+        else:
+            warnings.warn(
+                "Default value for argument {} of {} could not be "
+                "resolved.".format(arg, cls)
+            )
+            return value
+
+
+def autodoc_defaults(
+    app, what, name, obj, options, signature, return_annotation
+):
+    if what != "class":
+        return signature, return_annotation
+    spec = inspect.getfullargspec(obj.__init__)
+    if spec.defaults is not None:
+        defaults = [
+            resolve_default(obj, arg, d)
+            for arg, d in zip(spec.args[-len(spec.defaults):], spec.defaults)
+        ]
+    else:
+        defaults = None
+    return (
+        inspect.formatargspec(
+            spec.args,
+            spec.varargs,
+            spec.varkw,
+            defaults,
+            spec.kwonlyargs,
+            spec.kwonlydefaults,
+            spec.annotations,
+        ),
+        return_annotation,
+    )
+
+
+def setup(app):
+    app.connect("autodoc-process-signature", autodoc_defaults)


### PR DESCRIPTION
https://github.com/nengo/nengo/pull/1377 added a sphinx extension for expanding parameters with the `Default` value, this moves it into `nengo-sphinx-theme` so that it is available for any nengo projects that want to use it.