### PR TITLE
Search function no longer hangs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,11 @@ Release History
 1.0.2 (unreleased)
 ==================
 
+**Fixed**
 
+- Fixed the search box, which was hanging for many search terms.
+  (`#28 <https://github.com/nengo/nengo-sphinx-theme/issues/28>`__,
+  `#39 <https://github.com/nengo/nengo-sphinx-theme/pull/39>`__)
 
 1.0.1 (July 16, 2019)
 =====================

--- a/nengo_sphinx_theme/theme/layout.html
+++ b/nengo_sphinx_theme/theme/layout.html
@@ -68,7 +68,7 @@
       <div class="col-12 col-md-8 col-xl-9">
         <div class="container">
           <div class="row">
-            <div class="col-10 offset-1 pb-5 documentation-source">
+            <div class="col-10 offset-1 pb-5 documentation-source" role="main">
               {% block body %} {% endblock %}
             </div>
           </div>


### PR DESCRIPTION
Fixes #28. Based on the fix in sphinx-doc/sphinx#6394.

To test this locally, `cd` to the folder where you've built the docs with sphinx, and run `python -m http.server` (you need the HTTP requests to do the search properly).

I also tested this remotely by pushing the docs to a `gh-pages` branch in one of my own repos (https://hunse.github.io/docs-test/).

This raises the idea that we might want to somehow track changes in the Sphinx repository to their themes, in case we need to make those changes to our themes as well. I don't think it needs to be anything automated, but we could make it part of the release procedure or something, and also keep track somewhere when we last checked the Sphinx repository for new changes.