### PR TITLE
Add numpydoc function to style test

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -43,6 +43,7 @@ setup_py:
     - matplotlib
     - nbsphinx
     - nengo
+    - numpydoc
   classifiers:
     - "Development Status :: 4 - Beta"
     - "Framework :: Nengo"

--- a/docs/style.rst
+++ b/docs/style.rst
@@ -119,6 +119,30 @@ Function:
 
     :raises TypeError: if *foo* is out of range
 
+Function documented with NumPyDoc:
+
+.. np:function:: frobfunc(foo=1, *, bar=False)
+
+    Parameters
+    ----------
+
+    foo : int
+        foobinate strength
+    bar : bool
+        enabled barring.
+
+        Barring requires a second paragraph.
+
+    Returns
+    -------
+    str
+        frobbed return
+
+    Raises
+    ------
+    TypeError
+        if *foo* is out of range
+
 Class:
 
 .. class:: FrobClass(foo=1, *, bar=False)

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ version = runpy.run_path(os.path.join(root, "nengo_sphinx_theme", "version.py"))
 ]
 
 install_req = ["sphinx>=1.8"]
-docs_req = ["jupyter", "matplotlib", "nbsphinx", "nengo"]
+docs_req = ["jupyter", "matplotlib", "nbsphinx", "nengo", "numpydoc"]
 optional_req = []
 tests_req = []
 


### PR DESCRIPTION
This PR adds a section to the style test page with a NumPyDoc function with a parameter entry with multiple paragraphs. There was previously no spacing between paragraphs in a parameter section. https://github.com/nengo/nengo.github.io/pull/86 adds the CSS to add the spacing; this PR makes it possible to test the change.

Before CSS change:

![before](https://user-images.githubusercontent.com/203709/67444092-9f3e2500-f5d5-11e9-9106-e8414d3c4f52.png)

After CSS change:
![after](https://user-images.githubusercontent.com/203709/67444234-2ab7b600-f5d6-11e9-8767-8585a60a9a4c.png)
