### PR TITLE
Add redirects extension

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -69,6 +69,8 @@ docs_conf_py:
     - nengo_sphinx_theme.ext.resolvedefaults
     - nengo_sphinx_theme.ext.autoautosummary
   analytics_id: UA-41658423-2
+  html_redirects:
+    redirect/to/nested-page.html: deeply/nested/testing/page.html
 
 pre_commit_config_yaml: {}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,6 @@
 
 repos:
 -   repo: https://github.com/psf/black
-    rev: stable
+    rev: 19.10b0
     hooks:
     - id: black

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,10 @@ Release History
 1.1.1 (unreleased)
 ==================
 
+**Added**
 
+- Added an extension to handle redirecting old HTML pages to new ones.
+  (`#48 <https://github.com/nengo/nengo-sphinx-theme/pull/48>`__)
 
 1.1.0 (November 5, 2019)
 ========================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,6 +9,7 @@ import nengo_sphinx_theme
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
+    "sphinx.ext.doctest",
     "sphinx.ext.githubpages",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
@@ -25,6 +26,11 @@ extensions = [
 autoclass_content = "both"  # class and __init__ docstrings are concatenated
 autodoc_default_options = {"members": None}
 autodoc_member_order = "bysource"  # default is alphabetical
+
+# -- sphinx.ext.doctest
+doctest_global_setup = """
+import nengo_sphinx_theme
+"""
 
 # -- sphinx.ext.intersphinx
 intersphinx_mapping = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "nbsphinx",
     "nengo_sphinx_theme",
+    "nengo_sphinx_theme.ext.redirects",
     "numpydoc",
     "nengo_sphinx_theme.ext.resolvedefaults",
     "nengo_sphinx_theme.ext.autoautosummary",
@@ -84,3 +85,6 @@ html_theme_options = {
     "nengo_logo_color": "#a8acaf",
     "analytics_id": "UA-41658423-2",
 }
+html_redirects = [
+    ("redirect/to/nested-page.html", "deeply/nested/testing/page.html"),
+]

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -39,3 +39,12 @@ AutoAutoSummary
       :nosignatures:
 
       nengo_sphinx_theme.ext.autoautosummary.TestClass._another_private_method
+
+Redirects
+=========
+
+.. automodule:: nengo_sphinx_theme.ext.redirects
+   :no-members:
+
+The following page should redirect to the
+`deeply nested testing page <redirect/to/nested-page.html>`_.

--- a/nengo_sphinx_theme/ext/autoautosummary.py
+++ b/nengo_sphinx_theme/ext/autoautosummary.py
@@ -1,5 +1,8 @@
 """
 This extension automatically generates AutoSummaries for modules/classes.
+
+This extension can be enabled by adding ``"nengo_sphinx_theme.ext.autoautosummary"``
+to the ``extensions`` list in ``conf.py``.
 """
 
 import inspect

--- a/nengo_sphinx_theme/ext/redirects.py
+++ b/nengo_sphinx_theme/ext/redirects.py
@@ -1,0 +1,69 @@
+"""
+This extension generates pages to redirect a URL from an old location to a new one.
+These pages will only be generated when building with the HTML builder.
+
+This extension can be enabled by adding ``"nengo_sphinx_theme.ext.redirects"``
+to the ``extensions`` list in ``conf.py``.
+
+This extension adds a new configuration option to ``conf.py`` called
+``html_redirects``. ``html_redirects`` is a list of tuples, where each tuple has
+two elements: the original location and the new location. Locations are usually
+strings pointing to HTML files, but the new location can also be an anchor link
+or some other valid URL.
+
+As an example, suppose we rename a file from ``user_guide.rst`` to ``user-guide.rst``,
+and move the content on ``dev_guide.rst`` to a section in ``user-guide.rst``.
+The redirects might look like this::
+
+   html_redirects = [
+       ("user_guide.html", "user-guide.html"),
+       ("dev_guide.html", "user-guide.html#developers")
+   ]
+
+"""
+
+import errno
+import os
+from textwrap import dedent
+
+
+def mkdir_p(path):
+    try:
+        os.makedirs(path)
+    except OSError as exc:
+        if exc.errno == errno.EEXIST and os.path.isdir(path):
+            pass
+        else:
+            raise
+
+
+out_html = dedent(
+    """\
+    <!DOCTYPE html>
+    <html>
+      <head><title>This page has moved</title></head>
+      <body>
+        <script type="text/javascript">
+          window.location.replace("{0}");
+        </script>
+        <noscript>
+          <meta http-equiv="refresh" content="0; url={0}">
+        </noscript>
+      </body>
+    </html>
+    """
+).rstrip(" ")
+
+
+def setup(app):
+    def redirect_pages(app, docname):
+        if app.builder.name == "html":
+            for src, dst in app.config.html_redirects:
+                srcfile = os.path.join(app.outdir, src)
+                dsturl = "/".join([".." for _ in range(src.count("/"))] + [dst])
+                mkdir_p(os.path.dirname(srcfile))
+                with open(srcfile, "w") as fp:
+                    fp.write(out_html.format(dsturl))
+
+    app.add_config_value("html_redirects", [], "")
+    app.connect("build-finished", redirect_pages)


### PR DESCRIPTION
This is mostly a copy of the [`redirects` part of NengoDL's conf.py](https://github.com/nengo/nengo-dl/blob/master/docs/conf.py#L98), which I believe came from somewhere else (maybe the old nengo.github.io?)

It adds a `html_redirects` configuration option, which builds redirect pages. See the diff for more details.

It's tested through a redirect that is defined in the extensions page. In order to get the `html_redirects` into `conf.py`, you need <bones PR>.