### PR TITLE
Allow renaming in autoautosummary

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -38,6 +38,7 @@ setup_py:
   include_package_data: True
   install_req:
     - sphinx>=1.8
+    - backoff>=1.10.0
   docs_req:
     - jupyter
     - matplotlib

--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -71,6 +71,10 @@ docs_conf_py:
   analytics_id: UA-41658423-2
   html_redirects:
     redirect/to/nested-page.html: deeply/nested/testing/page.html
+  autoautosummary_change_modules:
+    nengo_sphinx_theme.ext.renamed_autoautosummary:
+      - nengo_sphinx_theme.ext.autoautosummary.TestClass
+      - nengo_sphinx_theme.ext.autoautosummary.a_test_function
 
 pre_commit_config_yaml: {}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,12 @@ notifications:
     on_failure: change
 cache: pip
 
-dist: trusty
+dist: xenial
 
 env:
   global:
     - SCRIPT="test"
     - TEST_ARGS=""
-    - COV_CORE_SOURCE=nengo_sphinx_theme  # early start pytest-cov engine
-    - COV_CORE_CONFIG=.coveragerc
-    - COV_CORE_DATAFILE=.coverage.eager
     - BRANCH_NAME="${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}"
 
 jobs:
@@ -43,14 +40,15 @@ jobs:
         distributions: "sdist bdist_wheel "
         on:
           all_branches: true
+          tags: false
           condition: $TRAVIS_BRANCH =~ ^release-candidate-*
-          condition: $TRAVIS_TAG = ""
       - provider: pypi
         user: tbekolay
         password: $PYPI_TOKEN
         distributions: "sdist bdist_wheel "
         on:
           all_branches: true
+          tags: true
           condition: $TRAVIS_TAG =~ ^v[0-9]*
 
 before_install:
@@ -71,7 +69,7 @@ before_install:
   - if [[ "$TRAVIS_PYTHON_VERSION" < "3.6" ]]; then
         echo "Skipping bones-check because Python $TRAVIS_PYTHON_VERSION < 3.6";
     else
-        bones-check;
+        bones-check --verbose;
     fi
   # display environment info
   - pip freeze

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,9 @@ Release History
   ``nengo_sphinx_theme.ext.autoautosummary``, which allows classes/functions
   documented with ``autoautosummary`` or ``automodule`` to be moved to a different
   nominal namespace. (`#52 <https://github.com/nengo/nengo-sphinx-theme/pull/52>`__)
+- Added ``nengo_sphinx_theme.ext.backoff``, which monkeypatches the Sphinx
+  HTTP request functionality to add exponential backoff.
+  (`#53 <https://github.com/nengo/nengo-sphinx-theme/pull/53>`__)
 
 1.2.0 (November 14, 2019)
 =========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,12 @@ Release History
 1.2.1 (unreleased)
 ==================
 
+**Added**
+
+- Added the ``autoautosummary_change_modules`` config option to
+  ``nengo_sphinx_theme.ext.autoautosummary``, which allows classes/functions
+  documented with ``autoautosummary`` or ``automodule`` to be moved to a different
+  nominal namespace. (`#52 <https://github.com/nengo/nengo-sphinx-theme/pull/52>`__)
 
 1.2.0 (November 14, 2019)
 =========================

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -4,7 +4,7 @@
 Nengo Sphinx Theme license
 **************************
 
-Copyright (c) 2019-2019 Applied Brain Research
+Copyright (c) 2019-2020 Applied Brain Research
 
 Nengo Sphinx Theme is made available under a proprietary license
 that permits using, copying, sharing, and making derivative works from

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,7 +77,7 @@ user_agent = "nengo_sphinx_theme"
 
 project = "Nengo Sphinx Theme"
 authors = "Applied Brain Research"
-copyright = "2019-2019 Applied Brain Research"
+copyright = "2019-2020 Applied Brain Research"
 version = ".".join(nengo_sphinx_theme.__version__.split(".")[:2])  # Short X.Y version
 release = nengo_sphinx_theme.__version__  # Full version, with tags
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,6 +49,14 @@ numpydoc_show_class_members = False
 # -- nbsphinx
 nbsphinx_timeout = -1
 
+# -- nengo_sphinx_theme.ext.autoautosummary
+autoautosummary_change_modules = {
+    "nengo_sphinx_theme.ext.renamed_autoautosummary": [
+        "nengo_sphinx_theme.ext.autoautosummary.TestClass",
+        "nengo_sphinx_theme.ext.autoautosummary.a_test_function",
+    ],
+}
+
 # -- sphinx
 nitpicky = True
 exclude_patterns = [

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "nbsphinx",
     "nengo_sphinx_theme",
+    "nengo_sphinx_theme.ext.backoff",
     "nengo_sphinx_theme.ext.redirects",
     "numpydoc",
     "nengo_sphinx_theme.ext.resolvedefaults",
@@ -72,6 +73,7 @@ linkcheck_ignore = [r"http://localhost:\d+"]
 linkcheck_anchors = True
 default_role = "py:obj"
 pygments_style = "sphinx"
+user_agent = "nengo_sphinx_theme"
 
 project = "Nengo Sphinx Theme"
 authors = "Applied Brain Research"

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -38,7 +38,7 @@ AutoAutoSummary
    .. autoautosummary:: nengo_sphinx_theme.ext.autoautosummary.TestClass
       :nosignatures:
 
-      nengo_sphinx_theme.ext.autoautosummary.TestClass._another_private_method
+      nengo_sphinx_theme.ext.renamed_autoautosummary.TestClass._another_private_method
 
 Redirects
 =========

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -48,3 +48,8 @@ Redirects
 
 The following page should redirect to the
 `deeply nested testing page <redirect/to/nested-page.html>`_.
+
+Backoff
+=======
+
+.. automodule:: nengo_sphinx_theme.ext.backoff

--- a/nengo_sphinx_theme/__init__.py
+++ b/nengo_sphinx_theme/__init__.py
@@ -7,7 +7,7 @@ from .version import version as __version__
 
 assert __version__
 
-__copyright__ = "2018 Applied Brain Research"
+__copyright__ = "2018-2020 Applied Brain Research"
 current_dir = os.path.abspath(os.path.dirname(__file__))
 
 

--- a/nengo_sphinx_theme/ext/__init__.py
+++ b/nengo_sphinx_theme/ext/__init__.py
@@ -1,0 +1,2 @@
+# for testing the renaming functionality in autoautosummary
+from nengo_sphinx_theme.ext import autoautosummary as renamed_autoautosummary

--- a/nengo_sphinx_theme/ext/backoff.py
+++ b/nengo_sphinx_theme/ext/backoff.py
@@ -1,0 +1,33 @@
+"""
+Monkeypatches the Sphinx HTTP request functions to add exponential backoff.
+
+The main use case for this is to avoid server-side rejections caused by too many
+requests when running the linkchecker.
+"""
+
+import requests
+
+import backoff
+from sphinx.util import requests as sphinx_requests
+from sphinx.util.requests import get, head
+
+
+@backoff.on_predicate(backoff.expo, lambda x: x.status_code == 429, max_time=60)
+@backoff.on_exception(
+    backoff.constant, requests.exceptions.RequestException, max_tries=3,
+)
+def get_with_backoff(*args, **kwargs):
+    return get(*args, **kwargs)
+
+
+@backoff.on_predicate(backoff.expo, lambda x: x.status_code == 429, max_time=60)
+@backoff.on_exception(
+    backoff.constant, requests.exceptions.RequestException, max_tries=3,
+)
+def head_with_backoff(*args, **kwargs):
+    return head(*args, **kwargs)
+
+
+def setup(_):
+    sphinx_requests.get = get_with_backoff
+    sphinx_requests.head = head_with_backoff

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ version = runpy.run_path(os.path.join(root, "nengo_sphinx_theme", "version.py"))
 
 install_req = [
     "sphinx>=1.8",
+    "backoff>=1.10.0",
 ]
 docs_req = [
     "jupyter",


### PR DESCRIPTION
This allows the module of classes/functions to be changed when using `automodule` or `autoautosummary`, so that things can be documented in different namespaces.

Note: depends on https://github.com/nengo/nengo-bones/pull/86