### PR TITLE
Sphinx 3.0 compatibility fixes

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -14,6 +14,15 @@ travis_yml:
   deploy_dists:
     - sdist
     - bdist_wheel
+  slack_notifications: "Z7RbxwewCMpVGFmJTESN3qsW3Oe3p5ZUgHtAZAvfYWnQCA0aEBAZF1tJyKfXw4z\
+    tl0JCSm0raPkKAGk6tNrQoRb0VzEltH2n9nyfuVedsQrC2PRa6Mq270Soct6DHqQuKbLyuoJZlAAqzmfD8\
+    2gdddkEkO2jL72f8b/ypXlWfgT4/+rFPdxDzVuj+/HMEpnM+7//8/v8XQfoWwfqYrxJ/eo95T/RxOhQR3G\
+    fGogfQkY2uFbs9ajdQDQ9xsqo/+qCCg5YoPGMDpacXu4uMBZ5OydguuJOYANBDQQhPWrPI2YncA38oCl5z\
+    ZuTQZnAGDYTOiOhcofPQY0paFZ7lRCfJu+kLiJWxQy1wOaUyPsRG/tO4ZgIx2jfVPeKzyGebVCQPmUjytQ\
+    l8Ed1w/FMi3eK5+xQQPMC3hCXVAYIrAIl8nK0k/N5ASg5mDMXmG4a2NRCJVZasrb4oMGuLMhprht2c8DdX\
+    3zw7kganRPIu7kpreUE908Yj2gHqCxWlI3AhfuU/ZiW7S1oMztjt+abaEJN/yPgyQqFbk6C9ml5l2LOg21\
+    ACU1BFlpimHb8UhXKL6pK+NaIAmlpifwhpJifAUe5Ij1+8v3BfWkVG73j19h3hA1m2XSIO6RXpOkUZpGSa\
+    TmMnx2kr+W2msM6VtAvL2dSS82ueTlrvy1F6AY3JNnXUgU="
 
 ci_scripts:
   - template: static

--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -76,6 +76,8 @@ docs_conf_py:
     nengo_sphinx_theme.ext.renamed_autoautosummary:
       - nengo_sphinx_theme.ext.autoautosummary.TestClass
       - nengo_sphinx_theme.ext.autoautosummary.a_test_function
+  sphinx_options:
+    autodoc_typehints: "'none'"
 
 pre_commit_config_yaml: {}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,13 @@ notifications:
   email:
     on_success: change
     on_failure: change
+  slack:
+    if: branch = master
+    on_pull_requests: false
+    on_success: change
+    on_failure: always
+    rooms:
+      - secure: "Z7RbxwewCMpVGFmJTESN3qsW3Oe3p5ZUgHtAZAvfYWnQCA0aEBAZF1tJyKfXw4ztl0JCSm0raPkKAGk6tNrQoRb0VzEltH2n9nyfuVedsQrC2PRa6Mq270Soct6DHqQuKbLyuoJZlAAqzmfD82gdddkEkO2jL72f8b/ypXlWfgT4/+rFPdxDzVuj+/HMEpnM+7//8/v8XQfoWwfqYrxJ/eo95T/RxOhQR3GfGogfQkY2uFbs9ajdQDQ9xsqo/+qCCg5YoPGMDpacXu4uMBZ5OydguuJOYANBDQQhPWrPI2YncA38oCl5zZuTQZnAGDYTOiOhcofPQY0paFZ7lRCfJu+kLiJWxQy1wOaUyPsRG/tO4ZgIx2jfVPeKzyGebVCQPmUjytQl8Ed1w/FMi3eK5+xQQPMC3hCXVAYIrAIl8nK0k/N5ASg5mDMXmG4a2NRCJVZasrb4oMGuLMhprht2c8DdX3zw7kganRPIu7kpreUE908Yj2gHqCxWlI3AhfuU/ZiW7S1oMztjt+abaEJN/yPgyQqFbk6C9ml5l2LOg21ACU1BFlpimHb8UhXKL6pK+NaIAmlpifwhpJifAUe5Ij1+8v3BfWkVG73j19h3hA1m2XSIO6RXpOkUZpGSaTmMnx2kr+W2msM6VtAvL2dSS82ueTlrvy1F6AY3JNnXUgU="
 cache: pip
 
 dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ before_install:
   # upgrade pip
   - pip install pip --upgrade
   # install/run nengo-bones
-  - pip install nengo-bones
+  - pip install git+https://github.com/nengo/nengo-bones#egg=nengo-bones
   - bones-generate --output-dir .ci ci-scripts
   - if [[ "$TRAVIS_PYTHON_VERSION" < "3.6" ]]; then
         echo "Skipping bones-check because Python $TRAVIS_PYTHON_VERSION < 3.6";

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,11 @@ Release History
 1.2.2 (unreleased)
 ==================
 
+**Fixed**
+
+- ``nengo_sphinx_theme.ext.resolvedefaults`` will not touch signatures unless they
+  contain a ``Default`` value.
+  (`#54 <https://github.com/nengo/nengo-sphinx-theme/pull/54>`__)
 
 1.2.1 (March 19, 2019)
 ======================
@@ -34,7 +39,7 @@ Release History
   nominal namespace. (`#52 <https://github.com/nengo/nengo-sphinx-theme/pull/52>`__)
 - Added ``nengo_sphinx_theme.ext.backoff``, which monkeypatches the Sphinx
   HTTP request functionality to add exponential backoff.
-  (`#53 <https://github.com/nengo/nengo-sphinx-theme/pull/53>`__)
+  (`#52 <https://github.com/nengo/nengo-sphinx-theme/pull/52>`__)
 
 1.2.0 (November 14, 2019)
 =========================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,6 +74,7 @@ linkcheck_anchors = True
 default_role = "py:obj"
 pygments_style = "sphinx"
 user_agent = "nengo_sphinx_theme"
+autodoc_typehints = "none"
 
 project = "Nengo Sphinx Theme"
 authors = "Applied Brain Research"

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -28,6 +28,7 @@ AutoAutoSummary
 ===============
 
 .. automodule:: nengo_sphinx_theme.ext.autoautosummary
+   :exclude-members: TestClass
 
    .. autoautosummary:: nengo_sphinx_theme.ext.autoautosummary
       :exclude-members: setup

--- a/docs/style.rst
+++ b/docs/style.rst
@@ -121,7 +121,7 @@ Function:
 
 Function documented with NumPyDoc:
 
-.. np:function:: frobfunc(foo=1, *, bar=False)
+.. np:function:: npfrobfunc(foo=1, *, bar=False)
 
     Parameters
     ----------

--- a/nengo_sphinx_theme/ext/resolvedefaults.py
+++ b/nengo_sphinx_theme/ext/resolvedefaults.py
@@ -38,15 +38,17 @@ def resolve_default(cls, arg, value):
 
 def autodoc_defaults(app, what, name, obj, options, signature, return_annotation):
     if what != "class":
-        return signature, return_annotation
+        return None
     spec = inspect.getfullargspec(obj.__init__)
-    if spec.defaults is not None:
-        defaults = [
-            resolve_default(obj, arg, d)
-            for arg, d in zip(spec.args[-len(spec.defaults) :], spec.defaults)
-        ]
-    else:
-        defaults = None
+
+    if spec.defaults is None or not any(val is Default for val in spec.defaults):
+        return None
+
+    defaults = [
+        resolve_default(obj, arg, d)
+        for arg, d in zip(spec.args[-len(spec.defaults) :], spec.defaults)
+    ]
+
     # pylint: disable=deprecated-method
     return (
         inspect.formatargspec(


### PR DESCRIPTION
Sphinx 3.0 broke some things in the documentation for this repo.

One is that duplicate objects in the documentation became an explicit error (previously it would just pick one as the canonical definition). So I just removed the duplicates we had.

The other is that the use of type annotations is now causing problems. We don't actually use type annotations ourselves, but some of the classes in AutoAutoSummary inherit from Sphinx classes, which do have type annotations. In Sphinx 2 it would just render these annotations as strings, but in Sphinx 3 it tries to look up the types as Sphinx references (so e.g. if the return type is specified as `None`, it tries to find a class named `None` and then fails). I'm not sure if this is an intentional change or a bug, there's nothing obviously related to this in the changelog. In any case we don't actually care about having working type annotations, so I just disabled them.

However, the `autodoc_typehints` option, which should disable the type annotations, didn't work because the ResolveDefaults extension would ignore that option and just add the full signature (including type annotations). So I modified ResolveDefaults so that it only touches signatures that actually contain a `Default` value. We would still have a problem if we ever wanted to use `ResolveDefaults` with type annotations, but I figure that's a problem for the future if we ever start using type annotations (and at that point the Sphinx bug might be fixed, if it is a bug).