### PR TITLE
Resolve module names in resolvedefaults

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -46,7 +46,7 @@ setup_py:
       - nengo_sphinx_theme=nengo_sphinx_theme
   include_package_data: True
   install_req:
-    - sphinx>=1.8
+    - sphinx>=3.0.0
     - backoff>=1.10.0
   docs_req:
     - jupyter

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,9 @@ Release History
 - ``nengo_sphinx_theme.ext.resolvedefaults`` will not touch signatures unless they
   contain a ``Default`` value.
   (`#54 <https://github.com/nengo/nengo-sphinx-theme/pull/54>`__)
+- ``nengo_sphinx_theme.ext.resolvedefaults`` will also resolve module objects to the
+  module name (rather than the file path).
+  (`#57 <https://github.com/nengo/nengo-sphinx-theme/pull/57>`__)
 
 1.2.1 (March 19, 2019)
 ======================

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -22,7 +22,15 @@ to the ``extensions`` list in ``conf.py``.
 
 Autodoc with default resolution:
 
+.. autofunction:: nengo_sphinx_theme.ext.resolvedefaults.test_func
+
 .. autoclass:: nengo_sphinx_theme.ext.resolvedefaults.TestClass
+
+Test built-in functions and classes:
+
+.. autofunction:: nengo_sphinx_theme.ext.resolvedefaults.test_builtin_func
+
+.. autoclass:: nengo_sphinx_theme.ext.resolvedefaults.TestBuiltinClass
 
 AutoAutoSummary
 ===============

--- a/nengo_sphinx_theme/ext/resolvedefaults.py
+++ b/nengo_sphinx_theme/ext/resolvedefaults.py
@@ -1,7 +1,18 @@
 import inspect
 import warnings
+import time
 
 from nengo.params import Default, IntParam, iter_params, StringParam
+import numpy as np
+
+
+def test_func(
+    param0=np.random,
+    param1=np.random.randint,
+    param2=np.random.RandomState,
+    param4=np.random.RandomState(),
+):
+    """Test that setting various different object types as args renders nicely."""
 
 
 class TestClass:
@@ -10,8 +21,19 @@ class TestClass:
     int_param = IntParam("int_param", default=1)
     str_param = StringParam("str_param", default="hello")
 
-    def __init__(self, int_param=Default, str_param=Default):
-        pass
+    def __init__(self, int_param=Default, str_param=Default, module_param=np.random):
+        """Init method"""
+
+    def another_method(self, module_param=np.random):
+        """A method"""
+
+
+# `inspect.signature` fails on built-ins; test that `autodoc_defaults` handles this
+test_builtin_func = time.time
+
+
+class TestBuiltinClass(np.random.RandomState):
+    pass
 
 
 class DisplayDefault:
@@ -19,50 +41,55 @@ class DisplayDefault:
         self.value = value
 
     def __repr__(self):
-        return "Default<{!r}>".format(self.value)
+        return self.value
 
 
-def resolve_default(cls, arg, value):
-    if value is not Default:
-        return value
+def resolve_default(cls, param):
+    if inspect.ismodule(param.default):
+        return DisplayDefault(param.default.__name__)
+    elif param.default is not Default:
+        return param.default
     else:
-        for param in (getattr(cls, name) for name in iter_params(cls)):
-            if param.name == arg:
-                return DisplayDefault(param.default)
+        for cls_param in (getattr(cls, name) for name in iter_params(cls)):
+            if cls_param.name == param.name:
+                return DisplayDefault("Default<{!r}>".format(cls_param.default))
         warnings.warn(
             "Default value for argument {} of {} could not be "
-            "resolved.".format(arg, cls)
+            "resolved.".format(param.name, cls)
         )
-        return value
+        return param.default
 
 
 def autodoc_defaults(app, what, name, obj, options, signature, return_annotation):
-    if what != "class":
-        return None
-    spec = inspect.getfullargspec(obj.__init__)
-
-    if spec.defaults is None or not any(val is Default for val in spec.defaults):
+    if what not in ("function", "method", "class"):
         return None
 
-    defaults = [
-        resolve_default(obj, arg, d)
-        for arg, d in zip(spec.args[-len(spec.defaults) :], spec.defaults)
+    try:
+        spec = inspect.signature(obj)
+    except ValueError as e:
+        if str(e).startswith("no signature found for builtin"):
+            return None
+        else:
+            raise
+
+    if not any(
+        inspect.ismodule(p.default) or p.default is Default
+        for p in spec.parameters.values()
+    ):
+        return None
+
+    new_params = [
+        p.replace(default=resolve_default(obj, p)) for p in spec.parameters.values()
     ]
-
-    # pylint: disable=deprecated-method
-    return (
-        inspect.formatargspec(
-            spec.args,
-            spec.varargs,
-            spec.varkw,
-            defaults,
-            spec.kwonlyargs,
-            spec.kwonlydefaults,
-            spec.annotations,
-        ),
-        return_annotation,
+    new_spec = spec.replace(
+        parameters=new_params, return_annotation=inspect.Signature.empty
     )
+
+    return str(new_spec), return_annotation
 
 
 def setup(app):
-    app.connect("autodoc-process-signature", autodoc_defaults)
+    # note: setting priority<500 so that this will be prioritized ahead of
+    # numpydoc's mangle_signature, otherwise it has no effect (as sphinx only applies
+    # the first non-None output from the list of listeners)
+    app.connect("autodoc-process-signature", autodoc_defaults, priority=499)

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ version = runpy.run_path(os.path.join(root, "nengo_sphinx_theme", "version.py"))
 ]
 
 install_req = [
-    "sphinx>=1.8",
+    "sphinx>=3.0.0",
     "backoff>=1.10.0",
 ]
 docs_req = [


### PR DESCRIPTION
When modules are used as kwarg defaults, by default that gets rendered in the function signature as the full path to the module's `__init__` file. This changes it so that it is rendered as the module name instead.

I added this into the `ResolveDefaults` extension, as there is a lot of code and conceptual overlap between the two. In both cases we're taking defaults that don't render very nicely and resolving them to something prettier. The diff of this merging is actually much smaller than it appears, because I also switched to using `inspect.Signature` objects, rather than the now-deprecated `inspect.formatargspec`.

One open question is whether there are any other default values we want to apply similar prettifying to. For example, setting 
```
param1=np.random.randint
param2=np.random.RandomState
param3=np.random.RandomState()
``` 
currently gets rendered as 
```
param1=<built-in method randint of numpy.random.mtrand.RandomState object at 0x000002A955566048>
param2=<class 'numpy.random.mtrand.RandomState'>
param3=RandomState(MT19937) at 0x2A956396360
```

We could also prettify those kinds of objects, to something like
```
param1=numpy.random.mtrand.RandomState.randint
param2=numpy.random.mtrand.RandomState
param3=RandomState(MT19937)
```

That definitely makes the docs more readable, but it's also probably touching more signatures (it's rare to use a module as a default, but less rare to use a class/method/function--although still kind of rare).

Fixes #46