### PR TITLE
Improve version dropdown

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,11 @@ Release History
 20.5 (unreleased)
 =================
 
+**Changed**
+
+- Swapped position of "search" and "version" boxes (so search is at the top
+  and version is at the bottom). (`#58`_)
+
 **Fixed**
 
 - Versions listed in the dropdown will now be sorted correctly by number rather than

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,13 @@ Release History
 20.5 (unreleased)
 =================
 
+**Fixed**
+
+- Versions listed in the dropdown will now be sorted correctly by number rather than
+  string (e.g. 1.10 will come after 1.2). (`#58`_)
+- Remove empty lines from version dropdown. (`#58`_)
+
+.. _#58: https://github.com/nengo/nengo-sphinx-theme/pull/58
 
 1.2.2 (April 14, 2020)
 ======================

--- a/docs/style.rst
+++ b/docs/style.rst
@@ -33,6 +33,8 @@ Email link: bob@example.com
 
 *Italic text*
 
+Sphinx reference: `.FrobClass`
+
 Math
 ====
 

--- a/nengo_sphinx_theme/__init__.py
+++ b/nengo_sphinx_theme/__init__.py
@@ -1,6 +1,7 @@
 import os
 import warnings
 
+from packaging.version import parse as parse_version
 from sphinx.errors import ConfigError
 
 from .version import version as __version__
@@ -56,3 +57,14 @@ def setup(app):
             )
 
     app.connect("config-inited", validate_config)
+
+    def add_jinja_filters(app):
+        def sort_versions(releases):
+            releases = [r for r in releases.split(",") if r.strip() != ""]
+            releases.sort(key=parse_version, reverse=True)
+            return releases
+
+        if app.builder.format == "html":
+            app.builder.templates.environment.filters["sort_versions"] = sort_versions
+
+    app.connect("builder-inited", add_jinja_filters)

--- a/nengo_sphinx_theme/theme/searchbox.html
+++ b/nengo_sphinx_theme/theme/searchbox.html
@@ -1,5 +1,5 @@
 {%- if pagename != "search" %}
-<form class="p-5 my-0 border-top" action="{{ pathto('search') }}" method="get">
+<form class="px-5 py-3 my-0 border-bottom" action="{{ pathto('search') }}" method="get">
   <div class="form-group form-group-single">
     <input type="text" name="q" class="form-control" placeholder="Search" />
     <input type="hidden" name="check_keywords" value="yes" />

--- a/nengo_sphinx_theme/theme/sidebar.html
+++ b/nengo_sphinx_theme/theme/sidebar.html
@@ -31,7 +31,7 @@
         {% else %}
         <option value="{{ prefix }}../{{ pagename }}.html">latest</option>
         {% endif %}
-        {% for release in releases.split(",") | sort(True) %}
+        {% for release in releases | sort_versions %}
           {% if building_version == release %}
         <option selected>{{ release }}</option>
           {% elif building_version == "latest" %}

--- a/nengo_sphinx_theme/theme/sidebar.html
+++ b/nengo_sphinx_theme/theme/sidebar.html
@@ -16,8 +16,13 @@
       {%- endif %}
     </a>
   </h3>
+  {%- include "searchbox.html" -%}
+  <div class="p-5 toctree">
+    {{ toctree(maxdepth=theme_sidebar_toc_depth|toint, collapse=True,
+    includehidden=theme_sidebar_includehidden|tobool) }}
+  </div>
   {% if building_version %}
-  <form class="px-5 pb-5 mb-0 mt-3 border-bottom">
+  <form class="p-5 my-0 border-top">
     <div class="form-group">
       <label class="text-gray">Version:</label>
       <select class="custom-select" onchange="switchVersion(this);">
@@ -48,9 +53,4 @@
     </div>
   </form>
   {% endif %}
-  <div class="p-5 toctree">
-    {{ toctree(maxdepth=theme_sidebar_toc_depth|toint, collapse=True,
-    includehidden=theme_sidebar_includehidden|tobool) }}
-  </div>
-  {%- include "searchbox.html" -%}
 </div>


### PR DESCRIPTION
- Removed blank entries in version dropdown
- Versions will now be sorted correctly (using version semantics rather than string)
- Swapped version and search box, and adjusted whitespace

See old:

<img width="331" alt="old" src="https://user-images.githubusercontent.com/1952220/79362860-7c098800-7f1d-11ea-845f-beeb7a85599b.PNG">

vs new:

<img width="330" alt="new" src="https://user-images.githubusercontent.com/1952220/79362866-7dd34b80-7f1d-11ea-9c71-387df2d60d8d.PNG">

Also added a sphinx reference to style.rst, since I'd been looking at that in other work and it didn't seem like it warranted its own PR.