### PR TITLE
Add option for docs with single page

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,11 @@ Release History
 20.5 (unreleased)
 =================
 
+**Added**
+
+- Added ``one_page`` theme option, which can be set to True for docs that include
+  all content on a single index page. (`#59`_)
+
 **Changed**
 
 - Swapped position of "search" and "version" boxes (so search is at the top
@@ -34,6 +39,7 @@ Release History
 - Remove empty lines from version dropdown. (`#58`_)
 
 .. _#58: https://github.com/nengo/nengo-sphinx-theme/pull/58
+.. _#59: https://github.com/nengo/nengo-sphinx-theme/pull/59
 
 1.2.2 (April 14, 2020)
 ======================

--- a/nengo_sphinx_theme/theme/sidebar.html
+++ b/nengo_sphinx_theme/theme/sidebar.html
@@ -18,8 +18,12 @@
   </h3>
   {%- include "searchbox.html" -%}
   <div class="p-5 toctree">
+  {% if theme_one_page %}
+    {{ toc }}
+  {% else %}
     {{ toctree(maxdepth=theme_sidebar_toc_depth|toint, collapse=True,
     includehidden=theme_sidebar_includehidden|tobool) }}
+  {% endif %}
   </div>
   {% if building_version %}
   <form class="p-5 my-0 border-top">

--- a/nengo_sphinx_theme/theme/theme.conf
+++ b/nengo_sphinx_theme/theme/theme.conf
@@ -10,3 +10,4 @@ nengo_ai = https://www.nengo.ai/
 nengo_logo =
 nengo_logo_color =
 analytics_id =
+one_page =


### PR DESCRIPTION
There isn't an easy way to test this within this repo, since everything shares the same sidebar. We'd have to build two versions of the docs and then somehow link them together. But it's a pretty minor change, and will be tested in downstream repos, so I figured that wasn't worth the effort.

Fixes #32