### PR TITLE
Add tagmanager_id theme option

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -78,7 +78,7 @@ docs_conf_py:
   extensions:
     - nengo_sphinx_theme.ext.resolvedefaults
     - nengo_sphinx_theme.ext.autoautosummary
-  analytics_id: UA-41658423-2
+  tagmanager_id: GTM-KWCR2HN
   html_redirects:
     redirect/to/nested-page.html: deeply/nested/testing/page.html
   autoautosummary_change_modules:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,6 @@
 
 repos:
 -   repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 20.8b0
     hooks:
     - id: black

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,8 @@ Release History
 
 **Added**
 
+- Added ``tagmanager_id`` theme option to enable Google Tag Manager tracking.
+  Note that ``tagmanager_id`` takes precedence over ``analytics_id``. (`#63`_)
 - Added ``one_page`` theme option, which can be set to True for docs that include
   all content on a single index page. (`#59`_)
 
@@ -42,6 +44,7 @@ Release History
 .. _#58: https://github.com/nengo/nengo-sphinx-theme/pull/58
 .. _#59: https://github.com/nengo/nengo-sphinx-theme/pull/59
 .. _#62: https://github.com/nengo/nengo-sphinx-theme/pull/62
+.. _#63: https://github.com/nengo/nengo-sphinx-theme/pull/63
 
 1.2.2 (April 14, 2020)
 ======================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,7 @@ import nengo_sphinx_theme
 # -- sphinx.ext.intersphinx
 intersphinx_mapping = {
     "nengo": ("https://www.nengo.ai/nengo/", None),
-    "numpy": ("https://docs.scipy.org/doc/numpy", None),
+    "numpy": ("https://numpy.org/doc/stable", None),
     "python": ("https://docs.python.org/3", None),
 }
 
@@ -94,7 +94,7 @@ html_favicon = os.path.join("_static", "favicon.ico")
 html_theme_options = {
     "nengo_logo": "general-full-light.svg",
     "nengo_logo_color": "#a8acaf",
-    "analytics_id": "UA-41658423-2",
+    "tagmanager_id": "GTM-KWCR2HN",
 }
 html_redirects = [
     ("redirect/to/nested-page.html", "deeply/nested/testing/page.html"),

--- a/nengo_sphinx_theme/__init__.py
+++ b/nengo_sphinx_theme/__init__.py
@@ -56,6 +56,14 @@ def setup(app):
                 "'UA-000000-2'; got %r" % (analytics_id,)
             )
 
+        # check Google Tag Manager container ID
+        tagmanager_id = theme_config.get("tagmanager_id", None)
+        if tagmanager_id is not None and not tagmanager_id.startswith("GTM-"):
+            warnings.warn(
+                "'tagmanager_id' looks strange. It should look like "
+                "'GTM-XXXXXXX'; got %r" % (tagmanager_id,)
+            )
+
     app.connect("config-inited", validate_config)
 
     def add_jinja_filters(app):

--- a/nengo_sphinx_theme/ext/backoff.py
+++ b/nengo_sphinx_theme/ext/backoff.py
@@ -14,7 +14,9 @@ from sphinx.util.requests import get, head
 
 @backoff.on_predicate(backoff.expo, lambda x: x.status_code == 429, max_time=60)
 @backoff.on_exception(
-    backoff.constant, requests.exceptions.RequestException, max_tries=3,
+    backoff.constant,
+    requests.exceptions.RequestException,
+    max_tries=3,
 )
 def get_with_backoff(*args, **kwargs):
     return get(*args, **kwargs)
@@ -22,7 +24,9 @@ def get_with_backoff(*args, **kwargs):
 
 @backoff.on_predicate(backoff.expo, lambda x: x.status_code == 429, max_time=60)
 @backoff.on_exception(
-    backoff.constant, requests.exceptions.RequestException, max_tries=3,
+    backoff.constant,
+    requests.exceptions.RequestException,
+    max_tries=3,
 )
 def head_with_backoff(*args, **kwargs):
     return head(*args, **kwargs)

--- a/nengo_sphinx_theme/theme/layout.html
+++ b/nengo_sphinx_theme/theme/layout.html
@@ -16,7 +16,22 @@
 {%- endblock %}
 
 {%- block scripts %}
-{%- if theme_analytics_id %}
+{%- if theme_tagmanager_id %}
+<!-- Google Tag Manager -->
+<script>
+ (function (w, d, s, l, i) {
+   w[l] = w[l] || [];
+   w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
+   var f = d.getElementsByTagName(s)[0],
+       j = d.createElement(s),
+       dl = l != "dataLayer" ? "&l=" + l : "";
+   j.async = true;
+   j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+   f.parentNode.insertBefore(j, f);
+ })(window, document, "script", "dataLayer", "{{ theme_tagmanager_id }}");
+</script>
+<!-- End Google Tag Manager -->
+{%- elif theme_analytics_id %}
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ theme_analytics_id }}"></script>
 <script>

--- a/nengo_sphinx_theme/theme/navbar.html
+++ b/nengo_sphinx_theme/theme/navbar.html
@@ -9,7 +9,7 @@
   ("divider", None),
   ("NengoFPGA", "https://www.nengo.ai/nengo-fpga/"),
   ("NengoLoihi", "https://www.nengo.ai/nengo-loihi/"),
-  ("NengoOCL", "https://github.com/nengo-labs/nengo-ocl"),
+  ("NengoOCL", "https://labs.nengo.ai/nengo-ocl/"),
   ("NengoSpiNNaker", "https://github.com/project-rig/nengo_spinnaker"),
   ("NengoMPI", "https://github.com/nengo-labs/nengo-mpi"),
   ("divider", None),

--- a/nengo_sphinx_theme/theme/theme.conf
+++ b/nengo_sphinx_theme/theme/theme.conf
@@ -10,4 +10,5 @@ nengo_ai = https://www.nengo.ai/
 nengo_logo =
 nengo_logo_color =
 analytics_id =
+tagmanager_id =
 one_page =

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,11 @@ setup(
         "tests": tests_req,
     },
     python_requires=">=3.5",
-    entry_points={"sphinx.html_themes": ["nengo_sphinx_theme=nengo_sphinx_theme",],},
+    entry_points={
+        "sphinx.html_themes": [
+            "nengo_sphinx_theme=nengo_sphinx_theme",
+        ],
+    },
     classifiers=[
         "Development Status :: 4 - Beta",
         "Framework :: Nengo",


### PR DESCRIPTION
Configuring this enables Google Tag Manager tracking. If both `analytics_id` and `tagmanager_id` are specified, only `tagmanager_id` will be used.

This and https://github.com/nengo/nengo-bones/pull/114 depend on each other.