### PR TITLE
Update dropdown order to match nengo.ai

### DIFF
--- a/nengo_sphinx_theme/theme/navbar.html
+++ b/nengo_sphinx_theme/theme/navbar.html
@@ -6,15 +6,14 @@
   ("NengoSPA", "https://www.nengo.ai/nengo-spa/"),
   ("NengoExtras", "https://www.nengo.ai/nengo-extras/"),
   ("Nengolib", "https://arvoelke.github.io/nengolib-docs/"),
+  ("KerasSpiking", "https://www.nengo.ai/keras-spiking"),
+  ("PyTorchSpiking", "https://www.nengo.ai/pytorch-spiking"),
   ("divider", None),
   ("NengoFPGA", "https://www.nengo.ai/nengo-fpga/"),
   ("NengoLoihi", "https://www.nengo.ai/nengo-loihi/"),
   ("NengoOCL", "https://labs.nengo.ai/nengo-ocl/"),
   ("NengoSpiNNaker", "https://github.com/project-rig/nengo_spinnaker"),
   ("NengoMPI", "https://github.com/nengo-labs/nengo-mpi"),
-  ("divider", None),
-  ("KerasSpiking", "https://www.nengo.ai/keras-spiking"),
-  ("PyTorchSpiking", "https://www.nengo.ai/pytorch-spiking"),
 ] %}
 
 <header class="fixed-top header-top shadow-sm">


### PR DESCRIPTION
Moves KerasSpiking and PytorchSpiking into the "Add ons" section.