### PR TITLE
Updates for Sphinx 4.0

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -46,13 +46,13 @@ setup_py:
       - nengo_sphinx_theme=nengo_sphinx_theme
   include_package_data: True
   install_req:
-    - sphinx>=3.1.2
+    - sphinx>=4.0.2
     - sphinx-notfound-page>=0.5.0
     - backoff>=1.10.0
   docs_req:
     - jupyter
     - matplotlib
-    - nbsphinx
+    - nbsphinx>=0.8.5
     - nengo
     - numpydoc
   classifiers:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ env:
     - SCRIPT="test"
     - TEST_ARGS=""
     - BRANCH_NAME="${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}"
-    - PIP_USE_FEATURE="2020-resolver"
 
 jobs:
   include:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,11 +22,16 @@ Release History
 20.10 (unreleased)
 ==================
 
+**Changed**
+
+- Added support for Sphinx 4.0, minimum Sphinx version is now 4.0. (`#71`_)
+
 **Fixed**
 
 - Aliases of renamed classes will now be handled correctly. (`#70`_)
 
 .. _#70: https://github.com/nengo/nengo-sphinx-theme/pull/70
+.. _#71: https://github.com/nengo/nengo-sphinx-theme/pull/71
 
 20.9 (September 9, 2020)
 ========================

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -26,10 +26,6 @@ If you want to fix a bug or add a feature to Nengo Sphinx Theme,
 we welcome pull requests.
 Ensure that you fill out all sections of the pull request template,
 deleting the comments as you go.
-We check most aspects of code style automatically.
-Please refer to our
-`code style guide <https://www.nengo.ai/nengo-bones/style.html>`_
-for things that we check manually.
 
 Contributor agreement
 =====================

--- a/nengo_sphinx_theme/ext/autoautosummary.py
+++ b/nengo_sphinx_theme/ext/autoautosummary.py
@@ -150,10 +150,10 @@ def patch_autosummary_import_by_name():
 
     orig_f = autosummary.import_by_name
 
-    def import_by_name(name, prefixes=None):
+    def import_by_name(name, prefixes=None, **kwargs):
         # We currently do not support prefixes, because they can cause cycles. If we
         # need this in the future, we can go back to filtering problematic prefixes.
-        return orig_f(name)
+        return orig_f(name, **kwargs)
 
     autosummary.import_by_name = import_by_name
 

--- a/nengo_sphinx_theme/ext/autoautosummary.py
+++ b/nengo_sphinx_theme/ext/autoautosummary.py
@@ -150,11 +150,10 @@ def patch_autosummary_import_by_name():
 
     orig_f = autosummary.import_by_name
 
-    def import_by_name(name, prefixes):
+    def import_by_name(name, prefixes=None):
         # We currently do not support prefixes, because they can cause cycles. If we
         # need this in the future, we can go back to filtering problematic prefixes.
-        prefixes = [None]
-        return orig_f(name, prefixes)
+        return orig_f(name)
 
     autosummary.import_by_name = import_by_name
 
@@ -192,7 +191,6 @@ class RenameClassDocumenter(RenameMixin, autodoc.ClassDocumenter):
     def add_content(self, more_content, no_docstring=False):
         # This is a modified version of autodoc.ClassDocumenter.add_content
         # that changes the module name for aliases
-        no_docstring = False
         if self.doc_as_attr:
             fullname = stringify(self.object)
             modname = self.env.config["autoautosummary_change_modules"].get(
@@ -202,12 +200,8 @@ class RenameClassDocumenter(RenameMixin, autodoc.ClassDocumenter):
             more_content = StringList(
                 [_(f"alias of :class:`{modname}.{fullname.split('.')[-1]}`")], source=""
             )
-            no_docstring = True
 
-        # no_docstring only needs to be specified in sphinx<3.4
-        super(autodoc.ClassDocumenter, self).add_content(
-            more_content, no_docstring=no_docstring
-        )
+        super(autodoc.ClassDocumenter, self).add_content(more_content)
 
 
 class RenameFunctionDocumenter(RenameMixin, autodoc.FunctionDocumenter):

--- a/setup.cfg
+++ b/setup.cfg
@@ -112,4 +112,4 @@ reports = no
 score = no
 
 [codespell]
-skip = ./build,*/_build,*-checkpoint.ipynb,./.eggs,./.git,*/_vendor,
+skip = ./build,*/_build,*-checkpoint.ipynb,./.eggs,./*.egg-info,./.git,*/_vendor,./.mypy_cache,

--- a/setup.py
+++ b/setup.py
@@ -30,14 +30,14 @@ root = pathlib.Path(__file__).parent
 version = runpy.run_path(str(root / "nengo_sphinx_theme" / "version.py"))["version"]
 
 install_req = [
-    "sphinx>=3.1.2",
+    "sphinx>=4.0.2",
     "sphinx-notfound-page>=0.5.0",
     "backoff>=1.10.0",
 ]
 docs_req = [
     "jupyter",
     "matplotlib",
-    "nbsphinx",
+    "nbsphinx>=0.8.5",
     "nengo",
     "numpydoc",
 ]


### PR DESCRIPTION
The prefixes argument is now optional in `import_by_name`, and the `no_docstring` argument is deprecated.