### PR TITLE
Restrict Sphinx version to <4.0

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -46,7 +46,7 @@ setup_py:
       - nengo_sphinx_theme=nengo_sphinx_theme
   include_package_data: True
   install_req:
-    - sphinx>=3.1.2
+    - sphinx>=3.1.2,<4.0
     - sphinx-notfound-page>=0.5.0
     - backoff>=1.10.0
   docs_req:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ env:
     - SCRIPT="test"
     - TEST_ARGS=""
     - BRANCH_NAME="${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}"
-    - PIP_USE_FEATURE="2020-resolver"
 
 jobs:
   include:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -26,10 +26,6 @@ If you want to fix a bug or add a feature to Nengo Sphinx Theme,
 we welcome pull requests.
 Ensure that you fill out all sections of the pull request template,
 deleting the comments as you go.
-We check most aspects of code style automatically.
-Please refer to our
-`code style guide <https://www.nengo.ai/nengo-bones/style.html>`_
-for things that we check manually.
 
 Contributor agreement
 =====================

--- a/setup.cfg
+++ b/setup.cfg
@@ -112,4 +112,4 @@ reports = no
 score = no
 
 [codespell]
-skip = ./build,*/_build,*-checkpoint.ipynb,./.eggs,./.git,*/_vendor,
+skip = ./build,*/_build,*-checkpoint.ipynb,./.eggs,./*.egg-info,./.git,*/_vendor,./.mypy_cache,

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ root = pathlib.Path(__file__).parent
 version = runpy.run_path(str(root / "nengo_sphinx_theme" / "version.py"))["version"]
 
 install_req = [
-    "sphinx>=3.1.2",
+    "sphinx>=3.1.2,<4.0",
     "sphinx-notfound-page>=0.5.0",
     "backoff>=1.10.0",
 ]


### PR DESCRIPTION
Sphinx 4.0 compatiblity is added in https://github.com/nengo/nengo-sphinx-theme/pull/71, but upgrading to Sphinx 4.0 could have effects in various downstream repos, which we don't have the cycles to deal with right now. So we'll just avoid Sphinx 4.0 until we have the cycles to check it in all our repos.